### PR TITLE
Set class attribute from mix-in getter

### DIFF
--- a/posmatch/core.py
+++ b/posmatch/core.py
@@ -64,7 +64,9 @@ class PosMatchMeta(type):
 
 class _InitParamsGetter:
     def __get__(self, instance, owner):
-        return _param_names_from_init(owner)
+        result = _param_names_from_init(owner)
+        owner.__match_args__ = result
+        return result
 
 
 class PosMatchMixin:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,7 +71,7 @@ class TestMatchArgsAttribute:
         # attribute must be defined on class, not instance
         assert "__match_args__" not in vars(instance)
 
-    def test_repeated_access_to_class_property_of_mixin(self, mixin_first):
+    def test_repeated_access_to_mixin_getter(self, mixin_first):
         expected = ("x", "y")
         assert mixin_first.__match_args__ == expected
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -67,7 +67,7 @@ class TestFullMatch:
             case _:
                 pytest.fail("Instance did not match pattern")
 
-    def test_repeated_access_to_class_property_of_mixin(self, mixin_first):
+    def test_repeated_access_to_mixin_getter(self, mixin_first):
         instance = mixin_first(1, 2)
 
         match instance:


### PR DESCRIPTION
Store the calculated value of match args in the `__match_args__` attribute of the respective class. As a result, the `__get__` method of the mix-in getter is only called once for each class. This makes subsequent attribute look-ups significantly faster.